### PR TITLE
Fix package dependencies and externals

### DIFF
--- a/.changeset/beige-dodos-attend.md
+++ b/.changeset/beige-dodos-attend.md
@@ -1,0 +1,10 @@
+---
+'@aside/chrome-ui-remote': patch
+'@aside/chrome-ui': patch
+'@aside/activity': patch
+'@aside/recoil': patch
+'@aside/react': patch
+'@aside/core': patch
+---
+
+Add proper package dependencies and externals during bundling

--- a/.yarnclean
+++ b/.yarnclean
@@ -1,0 +1,2 @@
+# Version conflict workarounds
+**/*/node_modules/@types/react/

--- a/app/package.json
+++ b/app/package.json
@@ -58,6 +58,6 @@
     "@aside/core": "0.7.1",
     "@aside/chrome-ui": "0.7.2",
     "react": "18.2.0",
-    "@remote-ui/react": "5.0.2"
+    "@remote-ui/react": ">=4.5.0 <6.0.0"
   }
 }

--- a/app/package.json
+++ b/app/package.json
@@ -57,6 +57,7 @@
     "@aside/react": "0.7.2",
     "@aside/core": "0.7.1",
     "@aside/chrome-ui": "0.7.2",
-    "react": "18.2.0"
+    "react": "18.2.0",
+    "@remote-ui/react": "5.0.2"
   }
 }

--- a/app/package.json
+++ b/app/package.json
@@ -58,6 +58,6 @@
     "@aside/core": "0.7.1",
     "@aside/chrome-ui": "0.7.2",
     "react": "18.2.0",
-    "@remote-ui/react": ">=4.5.0 <6.0.0"
+    "@remote-ui/react": "5.0.2"
   }
 }

--- a/examples/recoil-dev-tools/package.json
+++ b/examples/recoil-dev-tools/package.json
@@ -11,7 +11,6 @@
   "dependencies": {
     "@aside/react": "0.7.2",
     "@aside/recoil": "0.7.2",
-    "@aside/timeline": "0.3.0",
     "@aside/chrome-ui-remote": "0.1.2",
     "@aside/activity": "0.1.4",
     "recoil": "latest",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   "homepage": "https://github.com/alxclark/aside#readme",
   "dependencies": {
     "@changesets/cli": "^2.26.2",
-    "@remote-ui/react": "^4.5.0",
+    "@remote-ui/react": "5.0.2",
     "@remote-ui/rpc": "^1.3.1",
     "@remote-ui/async-subscription": "^2.1.14",
     "@shopify/react-testing": "^5.1.3",

--- a/package.json
+++ b/package.json
@@ -36,8 +36,9 @@
   "homepage": "https://github.com/alxclark/aside#readme",
   "dependencies": {
     "@changesets/cli": "^2.26.2",
-    "@remote-ui/react": "latest",
-    "@remote-ui/rpc": "latest",
+    "@remote-ui/react": "^4.5.0",
+    "@remote-ui/rpc": "^1.3.1",
+    "@remote-ui/async-subscription": "^2.1.14",
     "@shopify/react-testing": "^5.1.3",
     "@vitejs/plugin-react": "^4.0.3",
     "react": "^18.0.0",

--- a/packages/activity/CHANGELOG.md
+++ b/packages/activity/CHANGELOG.md
@@ -1,4 +1,4 @@
-# @aside/timeline
+# @aside/activity
 
 ## 0.1.4
 

--- a/packages/activity/package.json
+++ b/packages/activity/package.json
@@ -25,7 +25,9 @@
     "@aside/react": "^0.7.2",
     "@aside/chrome-ui-remote": "^0.1.2"
   },
-  "devDependencies": {},
+  "devDependencies": {
+    "@aside/core": "^0.7.1"
+  },
   "publishConfig": {
     "access": "public"
   }

--- a/packages/activity/package.json
+++ b/packages/activity/package.json
@@ -25,6 +25,9 @@
     "@aside/react": "^0.7.2",
     "@aside/chrome-ui-remote": "^0.1.2"
   },
+  "peerDependencies": {
+    "react": ">=17.0.0 <19.0.0"
+  },
   "devDependencies": {
     "@aside/core": "^0.7.1"
   },

--- a/packages/activity/src/hooks/use-activity.ts
+++ b/packages/activity/src/hooks/use-activity.ts
@@ -1,6 +1,6 @@
 import {useContext, useMemo} from 'react';
 import {useExtensionApi, useSubscription} from '@aside/react';
-import {GetterSetterTuple} from '@aside/core';
+import {type GetterSetterTuple} from '@aside/core';
 
 import {ActivityStoreContext} from '../contexts';
 import {ActivityContext} from '../types';

--- a/packages/activity/src/hooks/use-network-activity.ts
+++ b/packages/activity/src/hooks/use-network-activity.ts
@@ -1,5 +1,5 @@
 import {useNetwork} from '@aside/react';
-import {NetworkRequest} from '@aside/core';
+import {type NetworkRequest} from '@aside/core';
 import {useMemo} from 'react';
 
 import {ActivityStoreDescriptor, Snapshot} from '../types';

--- a/packages/activity/vite.config.ts
+++ b/packages/activity/vite.config.ts
@@ -8,7 +8,7 @@ import react from '@vitejs/plugin-react';
 export const r = (...args: string[]) => resolve(__dirname, '..', ...args);
 
 export default defineConfig({
-  plugins: [react()],
+  plugins: [],
   build: {
     emptyOutDir: false,
     outDir: 'build/js',

--- a/packages/activity/vite.config.ts
+++ b/packages/activity/vite.config.ts
@@ -19,14 +19,18 @@ export default defineConfig({
       fileName: (format) => `activity.${format}.js`,
     },
     rollupOptions: {
-      external: ['react', '@aside/react', '@aside/chrome-ui'],
+      external: [
+        'react',
+        '@aside/react',
+        '@aside/chrome-ui-remote',
+        '@aside/core',
+      ],
       output: {
         globals: {
           react: 'React',
-
+          '@aside/core': 'AsideCore',
           '@aside/react': 'AsideReact',
-
-          '@aside/chrome-ui': 'AsideChromeUi',
+          '@aside/chrome-ui-remote': 'AsideChromeUi',
         },
       },
     },
@@ -36,6 +40,7 @@ export default defineConfig({
       '@aside/react/testing': `${r('./react/src/testing/mount.tsx')}`,
       '@aside/react': `${r('./react/src')}`,
       '@aside/chrome-ui-remote': `${r('./chrome-ui-remote/src')}`,
+      '@aside/core': `${r('./core/src')}`,
     },
   },
   test: {

--- a/packages/chrome-ui-remote/package.json
+++ b/packages/chrome-ui-remote/package.json
@@ -20,8 +20,8 @@
     "build": "vite build",
     "clean": "rm -rf build"
   },
-  "peerDependencies": {
-    "@remote-ui/react": "^5.0.2"
+  "dependencies": {
+    "@remote-ui/react": "^4.5.0"
   },
   "devDependencies": {},
   "publishConfig": {

--- a/packages/chrome-ui-remote/package.json
+++ b/packages/chrome-ui-remote/package.json
@@ -23,6 +23,9 @@
   "dependencies": {
     "@remote-ui/react": "^4.5.0"
   },
+  "peerDependencies": {
+    "react": ">=17.0.0 <19.0.0"
+  },
   "devDependencies": {},
   "publishConfig": {
     "access": "public"

--- a/packages/chrome-ui-remote/package.json
+++ b/packages/chrome-ui-remote/package.json
@@ -21,7 +21,7 @@
     "clean": "rm -rf build"
   },
   "dependencies": {
-    "@remote-ui/react": "^4.5.0"
+    "@remote-ui/react": "5.0.2"
   },
   "peerDependencies": {
     "react": ">=17.0.0 <19.0.0"

--- a/packages/chrome-ui-remote/package.json
+++ b/packages/chrome-ui-remote/package.json
@@ -21,7 +21,7 @@
     "clean": "rm -rf build"
   },
   "dependencies": {
-    "@remote-ui/react": "5.0.2"
+    "@remote-ui/react": ">=4.5.0 <6.0.0"
   },
   "peerDependencies": {
     "react": ">=17.0.0 <19.0.0"

--- a/packages/chrome-ui-remote/src/components/Button.ts
+++ b/packages/chrome-ui-remote/src/components/Button.ts
@@ -1,9 +1,10 @@
+import {ButtonHTMLAttributes} from 'react';
 import {createRemoteReactComponent} from '@remote-ui/react';
 
 import {RemoteSafeAttributes} from '../types';
 
 export interface ButtonProps
-  extends RemoteSafeAttributes<React.ButtonHTMLAttributes<HTMLButtonElement>> {
+  extends RemoteSafeAttributes<ButtonHTMLAttributes<HTMLButtonElement>> {
   asChild?: boolean;
   variant?: 'default';
   size?: 'default' | 'icon';

--- a/packages/chrome-ui-remote/src/types.ts
+++ b/packages/chrome-ui-remote/src/types.ts
@@ -1,4 +1,4 @@
-import {DOMAttributes, HTMLAttributes} from 'react';
+import {type DOMAttributes, type HTMLAttributes} from 'react';
 
 /**
  * Aside's encoder strips out React's SyntheticBaseEvent

--- a/packages/chrome-ui/package.json
+++ b/packages/chrome-ui/package.json
@@ -32,8 +32,10 @@
     "@radix-ui/react-tabs": "^1.0.4",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.0.0",
-    "tailwind-merge": "^1.14.0",
-    "tailwindcss-animate": "^1.0.6"
+    "tailwind-merge": "^1.14.0"
+  },
+  "peerDependencies": {
+    "react": ">=17.0.0 <19.0.0"
   },
   "devDependencies": {
     "@aside/chrome-ui-remote": "^0.1.2",
@@ -41,7 +43,8 @@
     "classnames": "latest",
     "postcss": "^8.4.18",
     "postcss-cli": "^10.0.0",
-    "tailwindcss": "^3.3.5"
+    "tailwindcss": "^3.3.5",
+    "tailwindcss-animate": "^1.0.6"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/chrome-ui/vite.config.ts
+++ b/packages/chrome-ui/vite.config.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/naming-convention */
 import {resolve} from 'path';
 
 import {defineConfig} from 'vite';
@@ -13,10 +14,24 @@ export default defineConfig({
       fileName: (format) => `chrome-ui.${format}.js`,
     },
     rollupOptions: {
-      external: ['react'],
+      external: [
+        'react',
+        '@radix-ui/react-dropdown-menu',
+        '@radix-ui/react-slot',
+        '@radix-ui/react-tabs',
+        'class-variance-authority',
+        'clsx',
+        'tailwind-merge',
+      ],
       output: {
         globals: {
           react: 'React',
+          '@radix-ui/react-dropdown-menu': 'RadixUiReactDropdownMenu',
+          '@radix-ui/react-slot': 'RadixUiReactSlot',
+          '@radix-ui/react-tabs': 'RadixUiReactTabs',
+          'class-variance-authority': 'ClassVarianceAuthority',
+          clsx: 'Clsx',
+          'tailwind-merge': 'TailwindMerge',
         },
       },
     },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -2,14 +2,26 @@
   "name": "@aside/core",
   "version": "0.7.1",
   "type": "module",
-  "source": "src/index.ts",
-  "main": "src/index.ts",
   "license": "BSD-3-Clause",
+  "files": [
+    "build"
+  ],
+  "main": "./build/js/aside-core.umd.js",
+  "module": "./build/js/aside-core.es.js",
+  "exports": {
+    ".": {
+      "import": "./build/js/aside-core.es.js",
+      "require": "./build/js/aside-core.umd.js"
+    }
+  },
+  "types": "build/ts/index.d.ts",
   "scripts": {
     "type-check": "tsc",
+    "build": "vite build",
     "clean": "rm -rf build"
   },
   "dependencies": {},
+  "devDependencies": {},
   "publishConfig": {
     "access": "public"
   }

--- a/packages/core/src/adaptors/webpage.ts
+++ b/packages/core/src/adaptors/webpage.ts
@@ -1,7 +1,7 @@
 /* eslint-disable node/no-unsupported-features/node-builtins */
-import {MessageEndpoint} from '@remote-ui/rpc';
+import {type MessageEndpoint} from '@remote-ui/rpc';
 
-interface Options {
+export interface Options {
   targetOrigin?: string;
   context: string;
 }
@@ -83,24 +83,3 @@ function idToString(something: unknown) {
   }
   return something;
 }
-
-// ON RENDER -----
-// Apply (5) is what usually the CS will send to devtools with the whole React tree
-
-// ON STATE CHANGE -------
-// Apply (5) sends the diff of React tree (ie currentState)
-// Sent from content-script to Dev tools
-
-// ON RELOAD -----
-// 1. CS receives new connection from devtools
-// 2. CS calls rpc.unmount
-// 3. Content script tries to apply (5) onto the same ID that was used before the reload
-// [2, undefined, 0] ?
-// 4. CS releases ID used before reload (seems like a problem)
-// 5. Webpage calls rpc.mountDevtools (???)
-// 6. ERROR: Webpage receives function result (6) from RPC for (3.) and the function was already revoked
-// 7. CS tries to ask devtools for an RPC channel
-// 8. ERROR: CS receives result from (5.): Attempted to call a function that was already revoked
-// 9. Webpage receives channel from CS and devtools
-// 10. CS applies (5) the React tree with 100% of the UI from the client (full tree remount) => tries to use the previous channel
-// 11. Webpage receives ok from renderer.

--- a/packages/core/src/endpoints.ts
+++ b/packages/core/src/endpoints.ts
@@ -1,7 +1,7 @@
-import {RemoteChannel} from '@remote-ui/core';
+import {type RemoteChannel} from '@remote-ui/core';
 import {
-  RemoteSubscribable,
-  StatefulRemoteSubscribable,
+  type RemoteSubscribable,
+  type StatefulRemoteSubscribable,
 } from '@remote-ui/async-subscription';
 
 import {ExtensionApi, NetworkApi, NetworkRequest, StorageApi} from './api';

--- a/packages/core/vite.config.ts
+++ b/packages/core/vite.config.ts
@@ -1,0 +1,22 @@
+import {resolve} from 'path';
+
+import {defineConfig} from 'vite';
+
+export default defineConfig({
+  build: {
+    emptyOutDir: false,
+    outDir: 'build/js',
+    lib: {
+      entry: resolve(__dirname, 'src/index.ts'),
+      name: 'aside-core',
+      formats: ['es', 'umd'],
+      fileName: (format) => `aside-core.${format}.js`,
+    },
+    rollupOptions: {
+      external: [],
+      output: {
+        globals: {},
+      },
+    },
+  },
+});

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -31,11 +31,16 @@
     "clean": "rm -rf build"
   },
   "dependencies": {
-    "@aside/chrome-ui-remote": "0.1.2"
+    "@aside/chrome-ui-remote": "^0.1.2",
+    "@aside/core": "^0.7.1",
+    "@remote-ui/react": "^4.5.0",
+    "@remote-ui/rpc": "^1.3.1",
+    "@remote-ui/async-subscription": "^2.1.14"
   },
-  "devDependencies": {
-    "@aside/core": "^0.7.1"
+  "peerDependencies": {
+    "react": ">=17.0.0 <19.0.0"
   },
+  "devDependencies": {},
   "publishConfig": {
     "access": "public"
   }

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -33,7 +33,7 @@
   "dependencies": {
     "@aside/chrome-ui-remote": "^0.1.2",
     "@aside/core": "^0.7.1",
-    "@remote-ui/react": "5.0.2",
+    "@remote-ui/react": ">=4.5.0 <6.0.0",
     "@remote-ui/rpc": "^1.3.1",
     "@remote-ui/async-subscription": "^2.1.14"
   },

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -33,7 +33,7 @@
   "dependencies": {
     "@aside/chrome-ui-remote": "^0.1.2",
     "@aside/core": "^0.7.1",
-    "@remote-ui/react": "^4.5.0",
+    "@remote-ui/react": "5.0.2",
     "@remote-ui/rpc": "^1.3.1",
     "@remote-ui/async-subscription": "^2.1.14"
   },

--- a/packages/react/src/components/RemoteRenderer.tsx
+++ b/packages/react/src/components/RemoteRenderer.tsx
@@ -14,7 +14,7 @@ export function RemoteRenderer({
 
   useEffect(() => {
     return () => {
-      render(null, root, root.mount, reconciler);
+      render(null as any, root, root.mount, reconciler);
       onUnmount?.();
     };
   }, [onUnmount, root]);

--- a/packages/react/src/context.ts
+++ b/packages/react/src/context.ts
@@ -1,5 +1,5 @@
 import {createContext} from 'react';
-import {StatefullExtensionApi} from '@aside/core';
+import {type StatefullExtensionApi} from '@aside/core';
 
 export const ExtensionApiContext = createContext<
   StatefullExtensionApi | undefined

--- a/packages/react/src/hooks.ts
+++ b/packages/react/src/hooks.ts
@@ -7,7 +7,7 @@ import {
   useState,
 } from 'react';
 import type {StatefulRemoteSubscribable} from '@remote-ui/async-subscription';
-import {NetworkApi} from '@aside/core';
+import {type NetworkApi} from '@aside/core';
 
 import {ExtensionApiContext} from './context';
 import {ExtensionApi} from './types';

--- a/packages/react/src/types.ts
+++ b/packages/react/src/types.ts
@@ -1,5 +1,9 @@
-import {ActivityApi, NetworkRequest, StorageApi} from '@aside/core';
-import {StatefulRemoteSubscribable} from '@remote-ui/async-subscription';
+import {
+  type ActivityApi,
+  type NetworkRequest,
+  type StorageApi,
+} from '@aside/core';
+import {type StatefulRemoteSubscribable} from '@remote-ui/async-subscription';
 
 export interface ExtensionApi {
   network: {

--- a/packages/react/vite.config.ts
+++ b/packages/react/vite.config.ts
@@ -17,7 +17,6 @@ export default defineConfig({
       external: [
         'react',
         '@aside/chrome-ui-remote',
-        '@aside/timeline',
         '@aside/core',
         '@remote-ui/async-subscription',
         '@remote-ui/rpc',
@@ -27,7 +26,6 @@ export default defineConfig({
         globals: {
           react: 'React',
           '@aside/chrome-ui-remote': 'AsideChromeUiRemote',
-          '@aside/timeline': 'AsideTimeline',
           '@aside/core': 'AsideCore',
           '@remote-ui/async-subscription': 'RemoteUiAsyncSubscription',
           '@remote-ui/rpc': 'RemoteUiRpc',

--- a/packages/react/vite.config.ts
+++ b/packages/react/vite.config.ts
@@ -14,13 +14,24 @@ export default defineConfig({
       fileName: (format) => `aside-react.${format}.js`,
     },
     rollupOptions: {
-      external: ['react', '@aside-web', '@aside/chrome-ui', '@aside/timeline'],
+      external: [
+        'react',
+        '@aside/chrome-ui-remote',
+        '@aside/timeline',
+        '@aside/core',
+        '@remote-ui/async-subscription',
+        '@remote-ui/rpc',
+        '@remote-ui/react',
+      ],
       output: {
         globals: {
           react: 'React',
-          '@aside/react': 'AsideReact',
-          '@aside/chrome-ui': 'AsideChromeUi',
+          '@aside/chrome-ui-remote': 'AsideChromeUiRemote',
           '@aside/timeline': 'AsideTimeline',
+          '@aside/core': 'AsideCore',
+          '@remote-ui/async-subscription': 'RemoteUiAsyncSubscription',
+          '@remote-ui/rpc': 'RemoteUiRpc',
+          '@remote-ui/react': 'RemoteUiReact',
         },
       },
     },

--- a/packages/recoil/package.json
+++ b/packages/recoil/package.json
@@ -22,13 +22,15 @@
     "type-check": "tsc"
   },
   "dependencies": {
-    "@aside/react": "^0.7.2",
-    "recoil": "^0.7.5"
+    "@aside/activity": "^0.1.2"
+  },
+  "peerDependencies": {
+    "recoil": "^0.7.5",
+    "react": ">=17.0.0 <19.0.0"
   },
   "devDependencies": {
     "@aside/core": "^0.7.1",
-    "@aside/chrome-ui": "^0.7.2",
-    "@aside/activity": "^0.1.2"
+    "@aside/chrome-ui": "^0.7.2"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/recoil/src/tests/hooks.test.ts
+++ b/packages/recoil/src/tests/hooks.test.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/naming-convention */
-import {Snapshot} from 'recoil';
+import {type Snapshot} from 'recoil';
 
 import {transformSnapshot} from '../hooks';
 

--- a/packages/recoil/vite.config.ts
+++ b/packages/recoil/vite.config.ts
@@ -16,12 +16,13 @@ export default defineConfig({
       fileName: (format) => `recoil.${format}.js`,
     },
     rollupOptions: {
-      external: ['react', 'recoil', '@aside/react', '@aside/timeline'],
+      external: ['react', 'recoil', '@aside/react', '@aside/activity'],
       output: {
         globals: {
           react: 'React',
+          recoil: 'Recoil',
           '@aside/react': 'AsideReact',
-          '@aside/timeline': 'AsideTimeline',
+          '@aside/activity': 'AsideActivity',
         },
       },
     },

--- a/yarn.lock
+++ b/yarn.lock
@@ -2930,14 +2930,14 @@
   dependencies:
     "@babel/runtime" "^7.13.10"
 
-"@remote-ui/async-subscription@^2.1.13", "@remote-ui/async-subscription@^2.1.14":
+"@remote-ui/async-subscription@^2.1.14":
   version "2.1.14"
   resolved "https://registry.yarnpkg.com/@remote-ui/async-subscription/-/async-subscription-2.1.14.tgz#100f31a3e7d8d427ed13e064c335692abe320e20"
   integrity sha512-m4HQ7LmBNN80d5CDG1d0MzESfXQB3tPK3cEFannUoyqZybxZst/AB8TAnwKKZcXUR1eedkZMTqH6BjEgMRzulQ==
   dependencies:
     "@remote-ui/rpc" "^1.4.3"
 
-"@remote-ui/core@^2.2.0":
+"@remote-ui/core@^2.2.2":
   version "2.2.3"
   resolved "https://registry.yarnpkg.com/@remote-ui/core/-/core-2.2.3.tgz#5d53666d8bce9874d4976c21e88dd202e6080cd0"
   integrity sha512-LWwAlDJw9c+b61dViU6v8ivU0AalgGikvqidVoBLt+CLjTAXMwIkzIeYdjyRyp7JgGxnTYxnmVHUdJdxX144jg==
@@ -2945,27 +2945,21 @@
     "@remote-ui/rpc" "^1.4.3"
     "@remote-ui/types" "^1.1.3"
 
-"@remote-ui/react@^4.5.0":
-  version "4.6.0"
-  resolved "https://registry.yarnpkg.com/@remote-ui/react/-/react-4.6.0.tgz#1e62d5e22b85d57943520510bb924e6d8509a510"
-  integrity sha512-68hXreM9cMT5XhDTNcfTSsgYnjkdaK2/l9RPwTskWnaH/wgF5sjpInXsJFNLkJ2hTcWKspl3UKODWV4C68eq4A==
+"@remote-ui/react@5.0.2":
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/@remote-ui/react/-/react-5.0.2.tgz#449a935d53eb38265708f691bc9d57674d02be4b"
+  integrity sha512-v1C6QekhR6NrpzHA1dGMPun47N0TBb6VRq+yjIN5b6Z7i7wApf5+ifKc5gYouv4ENfoKPhatXAsOoYblG5iRpw==
   dependencies:
-    "@remote-ui/async-subscription" "^2.1.13"
-    "@remote-ui/core" "^2.2.0"
-    "@remote-ui/rpc" "^1.4.0"
-    "@types/react" ">=17.0.0 <18.0.0"
-    "@types/react-reconciler" "^0.26.0"
-    react-reconciler ">=0.26.0 <0.27.0"
+    "@remote-ui/async-subscription" "^2.1.14"
+    "@remote-ui/core" "^2.2.2"
+    "@remote-ui/rpc" "^1.4.3"
+    "@types/react" ">=17.0.0 <19.0.0"
+    "@types/react-reconciler" ">=0.26.0 <0.30.0"
 
-"@remote-ui/rpc@^1.3.1", "@remote-ui/rpc@^1.4.0":
+"@remote-ui/rpc@^1.3.1", "@remote-ui/rpc@^1.4.3":
   version "1.4.4"
   resolved "https://registry.yarnpkg.com/@remote-ui/rpc/-/rpc-1.4.4.tgz#94e93ee7adab34b599ac516817d78c04177b5be9"
   integrity sha512-3XVzEZSTxAw6c8ryDmds36M7QWWJW8Q7mxz+xInqkbrpOeSc6m1plGfNRFlbyaTq0puyH07dLjpsnl+HmWIacw==
-
-"@remote-ui/rpc@^1.4.3":
-  version "1.4.3"
-  resolved "https://registry.npmjs.org/@remote-ui/rpc/-/rpc-1.4.3.tgz"
-  integrity sha512-+XyELrHLIJVQEuidHoqZ32+drbphY/x697vykHCinTPhhuUiZpag1DnKSxoE4UlnwBzz336UtFHZIiDGtOL2Kg==
 
 "@remote-ui/types@^1.1.3":
   version "1.1.3"
@@ -4169,10 +4163,10 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react-reconciler@^0.26.0":
-  version "0.26.7"
-  resolved "https://registry.yarnpkg.com/@types/react-reconciler/-/react-reconciler-0.26.7.tgz#0c4643f30821ae057e401b0d9037e03e8e9b2a36"
-  integrity sha512-mBDYl8x+oyPX/VBb3E638N0B7xG+SPk/EAMcVPeexqus/5aTpTphQi0curhhshOqRrc9t6OPoJfEUkbymse/lQ==
+"@types/react-reconciler@>=0.26.0 <0.30.0":
+  version "0.28.6"
+  resolved "https://registry.yarnpkg.com/@types/react-reconciler/-/react-reconciler-0.28.6.tgz#8016038940cb0c12b54f422f41bd637d05aa4123"
+  integrity sha512-NlilRDg7yjtFX568NA046OiHWbz5EKM1q5FSXi2GP7WKyU+Vem4NJQcG+ZaMiWotyPiYqkIb6NKJkFuplbchAA==
   dependencies:
     "@types/react" "*"
 
@@ -4185,10 +4179,10 @@
     "@types/scheduler" "*"
     csstype "^3.0.2"
 
-"@types/react@>=17.0.0 <18.0.0":
-  version "17.0.69"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.69.tgz#245a0cf2f5b0fb1d645691d3083e3c7d4409b98f"
-  integrity sha512-klEeru//GhiQvXUBayz0Q4l3rKHWsBR/EUOhOeow6hK2jV7MlO44+8yEk6+OtPeOlRfnpUnrLXzGK+iGph5aeg==
+"@types/react@>=17.0.0 <19.0.0":
+  version "18.2.34"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-18.2.34.tgz#aed20f19473721ba328feb99d1ec3307ebc1a8dd"
+  integrity sha512-U6eW/alrRk37FU/MS2RYMjx0Va2JGIVXELTODaTIYgvWGCV4Y4TfTUzG8DdmpDNIT0Xpj/R7GfyHOJJrDttcvg==
   dependencies:
     "@types/prop-types" "*"
     "@types/scheduler" "*"
@@ -13811,15 +13805,6 @@ react-reconciler@0.29.0:
     loose-envify "^1.1.0"
     scheduler "^0.23.0"
 
-"react-reconciler@>=0.26.0 <0.27.0":
-  version "0.26.2"
-  resolved "https://registry.yarnpkg.com/react-reconciler/-/react-reconciler-0.26.2.tgz#bbad0e2d1309423f76cf3c3309ac6c96e05e9d91"
-  integrity sha512-nK6kgY28HwrMNwDnMui3dvm3rCFjZrcGiuwLc5COUipBK5hWHLOxMJhSnSomirqWwjPBJKV1QcbkI0VJr7Gl1Q==
-  dependencies:
-    loose-envify "^1.1.0"
-    object-assign "^4.1.1"
-    scheduler "^0.20.2"
-
 react-reconciler@^0.28.0:
   version "0.28.0"
   resolved "https://registry.yarnpkg.com/react-reconciler/-/react-reconciler-0.28.0.tgz#52ede33c584c9b6d4c9bea02a53d368c5751c9c9"
@@ -14482,14 +14467,6 @@ saxes@^6.0.0:
   integrity sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==
   dependencies:
     xmlchars "^2.2.0"
-
-scheduler@^0.20.2:
-  version "0.20.2"
-  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.20.2.tgz#4baee39436e34aa93b4874bddcbf0fe8b8b50e91"
-  integrity sha512-2eWfGgAqqWFGqtdMmcL5zCMK1U8KlXv8SQFGglL3CEtd0aDVDWgeF/YoCmvln55m5zSk3J/20hTaSBeSObsQDQ==
-  dependencies:
-    loose-envify "^1.1.0"
-    object-assign "^4.1.1"
 
 scheduler@^0.22.0:
   version "0.22.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -59,32 +59,6 @@
   dependencies:
     tslib "~2.0.1"
 
-"@aside/chrome-ui@0.6.0":
-  version "0.6.0"
-  resolved "https://registry.yarnpkg.com/@aside/chrome-ui/-/chrome-ui-0.6.0.tgz#e7bfc77494660081f431d232f07fdfac2eabd936"
-  integrity sha512-AhGP6THSol5R7V8CcHMY2huqaRcdOEU42JRTLJCYJedJ74HoxydeNhbaQ0FfE+pK875POa6XwVLHX7shT34tSQ==
-
-"@aside/react@0.6.0":
-  version "0.6.0"
-  resolved "https://registry.yarnpkg.com/@aside/react/-/react-0.6.0.tgz#679a8a32cd12cf73c65859ed953a93923cc1ba52"
-  integrity sha512-rhqVNyTai9dZ51eKUQY5Ye/yUVueNY8fVrreZ2bIHBs7kMIQMichJxASF+yiN4sp9khLhh671jWsgTKhjRfI0w==
-  dependencies:
-    "@aside/chrome-ui" "0.6.0"
-    "@aside/web" "0.6.0"
-
-"@aside/timeline@0.3.0":
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/@aside/timeline/-/timeline-0.3.0.tgz#97d923a0d89d58eb878886c49d2d0cf691f627ac"
-  integrity sha512-vchl6Hd4B/sxijxGT5Ignhibnt9mr+ZL+gsWjLtvRBasP+MPzZ8gBpJXkdiaJiDGJKuwZHiKwSvK4b/l0Mtzrw==
-  dependencies:
-    "@aside/chrome-ui" "0.6.0"
-    "@aside/react" "0.6.0"
-
-"@aside/web@0.6.0":
-  version "0.6.0"
-  resolved "https://registry.yarnpkg.com/@aside/web/-/web-0.6.0.tgz#f00667b6aa64e0ab8fcdf1b33d63e46959804cdf"
-  integrity sha512-0Zr+VbjQc17U7chNg0aYfs5sCWaGqxaTtps2Y6xpgvmY4CKNlLshaD0MkstOr1hQ1gC8bvFPPa2+2qmc5ezdYg==
-
 "@babel/code-frame@^7.0.0", "@babel/code-frame@^7.10.4", "@babel/code-frame@^7.16.0", "@babel/code-frame@^7.18.6", "@babel/code-frame@^7.5.5", "@babel/code-frame@^7.8.3":
   version "7.18.6"
   resolved "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.18.6.tgz"
@@ -2956,33 +2930,39 @@
   dependencies:
     "@babel/runtime" "^7.13.10"
 
-"@remote-ui/async-subscription@^2.1.14":
+"@remote-ui/async-subscription@^2.1.13", "@remote-ui/async-subscription@^2.1.14":
   version "2.1.14"
-  resolved "https://registry.npmjs.org/@remote-ui/async-subscription/-/async-subscription-2.1.14.tgz"
+  resolved "https://registry.yarnpkg.com/@remote-ui/async-subscription/-/async-subscription-2.1.14.tgz#100f31a3e7d8d427ed13e064c335692abe320e20"
   integrity sha512-m4HQ7LmBNN80d5CDG1d0MzESfXQB3tPK3cEFannUoyqZybxZst/AB8TAnwKKZcXUR1eedkZMTqH6BjEgMRzulQ==
   dependencies:
     "@remote-ui/rpc" "^1.4.3"
 
-"@remote-ui/core@^2.2.2":
+"@remote-ui/core@^2.2.0":
   version "2.2.3"
-  resolved "https://registry.npmjs.org/@remote-ui/core/-/core-2.2.3.tgz"
+  resolved "https://registry.yarnpkg.com/@remote-ui/core/-/core-2.2.3.tgz#5d53666d8bce9874d4976c21e88dd202e6080cd0"
   integrity sha512-LWwAlDJw9c+b61dViU6v8ivU0AalgGikvqidVoBLt+CLjTAXMwIkzIeYdjyRyp7JgGxnTYxnmVHUdJdxX144jg==
   dependencies:
     "@remote-ui/rpc" "^1.4.3"
     "@remote-ui/types" "^1.1.3"
 
-"@remote-ui/react@latest":
-  version "5.0.2"
-  resolved "https://registry.yarnpkg.com/@remote-ui/react/-/react-5.0.2.tgz#449a935d53eb38265708f691bc9d57674d02be4b"
-  integrity sha512-v1C6QekhR6NrpzHA1dGMPun47N0TBb6VRq+yjIN5b6Z7i7wApf5+ifKc5gYouv4ENfoKPhatXAsOoYblG5iRpw==
+"@remote-ui/react@^4.5.0":
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/@remote-ui/react/-/react-4.6.0.tgz#1e62d5e22b85d57943520510bb924e6d8509a510"
+  integrity sha512-68hXreM9cMT5XhDTNcfTSsgYnjkdaK2/l9RPwTskWnaH/wgF5sjpInXsJFNLkJ2hTcWKspl3UKODWV4C68eq4A==
   dependencies:
-    "@remote-ui/async-subscription" "^2.1.14"
-    "@remote-ui/core" "^2.2.2"
-    "@remote-ui/rpc" "^1.4.3"
-    "@types/react" ">=17.0.0 <19.0.0"
-    "@types/react-reconciler" ">=0.26.0 <0.30.0"
+    "@remote-ui/async-subscription" "^2.1.13"
+    "@remote-ui/core" "^2.2.0"
+    "@remote-ui/rpc" "^1.4.0"
+    "@types/react" ">=17.0.0 <18.0.0"
+    "@types/react-reconciler" "^0.26.0"
+    react-reconciler ">=0.26.0 <0.27.0"
 
-"@remote-ui/rpc@^1.4.3", "@remote-ui/rpc@latest":
+"@remote-ui/rpc@^1.3.1", "@remote-ui/rpc@^1.4.0":
+  version "1.4.4"
+  resolved "https://registry.yarnpkg.com/@remote-ui/rpc/-/rpc-1.4.4.tgz#94e93ee7adab34b599ac516817d78c04177b5be9"
+  integrity sha512-3XVzEZSTxAw6c8ryDmds36M7QWWJW8Q7mxz+xInqkbrpOeSc6m1plGfNRFlbyaTq0puyH07dLjpsnl+HmWIacw==
+
+"@remote-ui/rpc@^1.4.3":
   version "1.4.3"
   resolved "https://registry.npmjs.org/@remote-ui/rpc/-/rpc-1.4.3.tgz"
   integrity sha512-+XyELrHLIJVQEuidHoqZ32+drbphY/x697vykHCinTPhhuUiZpag1DnKSxoE4UlnwBzz336UtFHZIiDGtOL2Kg==
@@ -4189,10 +4169,10 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react-reconciler@>=0.26.0 <0.30.0":
-  version "0.28.1"
-  resolved "https://registry.npmjs.org/@types/react-reconciler/-/react-reconciler-0.28.1.tgz"
-  integrity sha512-ExBHUBykCcDh0HqqlJb6BA1yNpvW2iluIThK9tr1CX2tRMe3HeLt5/ow/bTpKGWoRBE5v/ISXFyjbnHRSKT6ng==
+"@types/react-reconciler@^0.26.0":
+  version "0.26.7"
+  resolved "https://registry.yarnpkg.com/@types/react-reconciler/-/react-reconciler-0.26.7.tgz#0c4643f30821ae057e401b0d9037e03e8e9b2a36"
+  integrity sha512-mBDYl8x+oyPX/VBb3E638N0B7xG+SPk/EAMcVPeexqus/5aTpTphQi0curhhshOqRrc9t6OPoJfEUkbymse/lQ==
   dependencies:
     "@types/react" "*"
 
@@ -4205,10 +4185,10 @@
     "@types/scheduler" "*"
     csstype "^3.0.2"
 
-"@types/react@>=17.0.0 <19.0.0":
-  version "18.0.26"
-  resolved "https://registry.npmjs.org/@types/react/-/react-18.0.26.tgz"
-  integrity sha512-hCR3PJQsAIXyxhTNSiDFY//LhnMZWpNNr5etoCqx/iUfGc5gXWtQR2Phl908jVR6uPXacojQWTg4qRpkxTuGug==
+"@types/react@>=17.0.0 <18.0.0":
+  version "17.0.69"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.69.tgz#245a0cf2f5b0fb1d645691d3083e3c7d4409b98f"
+  integrity sha512-klEeru//GhiQvXUBayz0Q4l3rKHWsBR/EUOhOeow6hK2jV7MlO44+8yEk6+OtPeOlRfnpUnrLXzGK+iGph5aeg==
   dependencies:
     "@types/prop-types" "*"
     "@types/scheduler" "*"
@@ -13831,6 +13811,15 @@ react-reconciler@0.29.0:
     loose-envify "^1.1.0"
     scheduler "^0.23.0"
 
+"react-reconciler@>=0.26.0 <0.27.0":
+  version "0.26.2"
+  resolved "https://registry.yarnpkg.com/react-reconciler/-/react-reconciler-0.26.2.tgz#bbad0e2d1309423f76cf3c3309ac6c96e05e9d91"
+  integrity sha512-nK6kgY28HwrMNwDnMui3dvm3rCFjZrcGiuwLc5COUipBK5hWHLOxMJhSnSomirqWwjPBJKV1QcbkI0VJr7Gl1Q==
+  dependencies:
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
+    scheduler "^0.20.2"
+
 react-reconciler@^0.28.0:
   version "0.28.0"
   resolved "https://registry.yarnpkg.com/react-reconciler/-/react-reconciler-0.28.0.tgz#52ede33c584c9b6d4c9bea02a53d368c5751c9c9"
@@ -14493,6 +14482,14 @@ saxes@^6.0.0:
   integrity sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==
   dependencies:
     xmlchars "^2.2.0"
+
+scheduler@^0.20.2:
+  version "0.20.2"
+  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.20.2.tgz#4baee39436e34aa93b4874bddcbf0fe8b8b50e91"
+  integrity sha512-2eWfGgAqqWFGqtdMmcL5zCMK1U8KlXv8SQFGglL3CEtd0aDVDWgeF/YoCmvln55m5zSk3J/20hTaSBeSObsQDQ==
+  dependencies:
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
 
 scheduler@^0.22.0:
   version "0.22.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -13988,7 +13988,7 @@ real-require@^0.2.0:
   resolved "https://registry.npmjs.org/real-require/-/real-require-0.2.0.tgz"
   integrity sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==
 
-recoil@^0.7.5, recoil@latest:
+recoil@latest:
   version "0.7.7"
   resolved "https://registry.npmjs.org/recoil/-/recoil-0.7.7.tgz"
   integrity sha512-8Og5KPQW9LwC577Vc7Ug2P0vQshkv1y3zG3tSSkWMqkWSwHmE+by06L8JtnGocjW6gcCvfwB3YtrJG6/tWivNQ==

--- a/yarn.lock
+++ b/yarn.lock
@@ -2945,7 +2945,7 @@
     "@remote-ui/rpc" "^1.4.3"
     "@remote-ui/types" "^1.1.3"
 
-"@remote-ui/react@5.0.2":
+"@remote-ui/react@5.0.2", "@remote-ui/react@>=4.5.0 <6.0.0":
   version "5.0.2"
   resolved "https://registry.yarnpkg.com/@remote-ui/react/-/react-5.0.2.tgz#449a935d53eb38265708f691bc9d57674d02be4b"
   integrity sha512-v1C6QekhR6NrpzHA1dGMPun47N0TBb6VRq+yjIN5b6Z7i7wApf5+ifKc5gYouv4ENfoKPhatXAsOoYblG5iRpw==


### PR DESCRIPTION
## Description

Packages were not set with proper externals, peer dependencies and direct dependencies. This caused package dependencies to be bundled multiple times with the actual library code instead of handing it over to the consumer to provide its code. This led to duplicate deps and bloated bundles.

## Results

* `@aside/core`
  * **Before**: 🔴 Broken
  * **After**: `gzip: 0.40 KiB`
* `@aside/chrome-ui-remote`
  * **Before**: `gzip: 0.61 KiB`
  * **After**: `gzip: 0.61 KiB` (unchanged 👍🏼)
* `@aside/react`
  * **Before**: `gzip: 114.75 KiB`
  * **After**: `gzip: 2.18 KiB`
* `@aside/activity`
  * **Before**: `gzip: 10.99 KiB`
  * **After**: `gzip: 4.48 KiB`
* `@aside/chrome-ui`
  * **Before**: `193.43 KiB`
  * **After**: `gzip: 10.86 KiB`
* `@aside/recoil`
  * **Before**: `gzip: 7.47 KiB`
  * **After**: `gzip:  0.64 KiB`

