### PR TITLE
Rework content-script to fix race-conditions

### DIFF
--- a/.changeset/khaki-schools-shake.md
+++ b/.changeset/khaki-schools-shake.md
@@ -1,0 +1,6 @@
+---
+'@aside/react': patch
+'@aside/core': patch
+---
+
+Fix connection issue between webpage and content-script

--- a/app/package.json
+++ b/app/package.json
@@ -58,6 +58,7 @@
     "@aside/core": "0.7.4",
     "@aside/chrome-ui": "0.7.5",
     "react": "18.2.0",
-    "@remote-ui/react": "5.0.2"
+    "@remote-ui/react": "5.0.2",
+    "@preact/signals-core": "^1.1.5"
   }
 }

--- a/app/src/foundation/ContentScript/ContentScript.ts
+++ b/app/src/foundation/ContentScript/ContentScript.ts
@@ -1,44 +1,37 @@
-import {createEndpoint, retain} from '@remote-ui/rpc';
-import type {Endpoint} from '@remote-ui/rpc';
-import {
-  ContentScriptApiForWebpage,
-  ContentScriptApiForDevtools,
-  DevtoolsApiForContentScript,
-  fromWebpage,
-  WebpageApi,
-} from '@aside/core';
 import {Runtime} from 'webextension-polyfill';
-import {type RemoteChannel} from '@remote-ui/core';
+import {effect} from '@preact/signals-core';
 
-import {createUnsafeEncoder} from '../Remote';
-import {fromPort} from '../Remote/rpc';
-
-import {WEBPAGE_INITIATED_CONNECTION} from './messages';
-
-interface Current {
-  webpage?: Endpoint<WebpageApi>;
-  devtools?: Endpoint<DevtoolsApiForContentScript>;
-  port?: Runtime.Port;
-}
+import {createReducer} from './reducer';
 
 export function contentScript() {
-  // Case 1:
-  // The webpage remote loads and expose methods before the content-script
-  // Case 2:
-  // The content-script loads before the remote is ready
-  // Case 3:
-  // The devtools loads ahead of the content-script and webpage
-
-  let state: State = {
+  const [stateSignal, dispatch] = createReducer({
     devtools: {
       ready: false,
     },
     webpage: {
       ready: false,
-      endpoint: createWebpageEndpoint(),
     },
-  };
+  });
 
+  // Initialize content-script.
+  // Some of the initialization cannot be done in the initial reducer state
+  // we provide above. For example, the webpage endpoint needs to be able
+  // to dispatch state changes, but this causes a chicken and egg problem.
+  dispatch({type: 'init'});
+
+  // Subscribe to ready events and mount app
+  effect(function mountWhenReady() {
+    if (stateSignal.value.devtools.ready && stateSignal.value.webpage.ready) {
+      stateSignal.value.webpage.endpoint.call.mountDevtools();
+    }
+  });
+
+  // Attempt to establish a port with the devtools panel.
+  // Depending on the timing of which script loads first,
+  // different means of connection are used.
+
+  // 1. Attempt to connect to devtools
+  // in case the devtools loaded first.
   const contentScriptPort = browser.runtime.connect({
     name: 'content-script',
   });
@@ -49,10 +42,10 @@ export function contentScript() {
     devtoolsPort: Runtime.Port,
   ) {
     if (message?.type === 'accept-port' && message?.sender === 'dev') {
-      state = reducer(state, {type: 'devtools-ready', port: devtoolsPort});
+      dispatch({type: 'devtools-ready', port: devtoolsPort});
 
       devtoolsPort.onDisconnect.addListener(() => {
-        state = reducer(state, {
+        dispatch({
           type: 'devtools-disconnected',
           port: devtoolsPort,
         });
@@ -60,16 +53,18 @@ export function contentScript() {
     }
   }
 
+  // 2. Listen to runtime connection
+  // in case the webpage loaded first.
   browser.runtime.onConnect.addListener(onConnectListener);
   async function onConnectListener(devtoolsPort: Runtime.Port) {
     devtoolsPort.postMessage({type: 'accept-port', sender: 'content-script'});
 
     const listener = (message: any) => {
       if (message.type === 'ready' && message.sender === 'dev') {
-        state = reducer(state, {type: 'devtools-ready', port: devtoolsPort});
+        dispatch({type: 'devtools-ready', port: devtoolsPort});
 
         devtoolsPort.onDisconnect.addListener(() => {
-          state = reducer(state, {
+          dispatch({
             type: 'devtools-disconnected',
             port: devtoolsPort,
           });
@@ -78,234 +73,4 @@ export function contentScript() {
     };
     devtoolsPort.onMessage.addListener(listener);
   }
-}
-
-interface State {
-  webpage: {
-    ready: boolean;
-    endpoint: Endpoint<WebpageApi>;
-  };
-  devtools: {
-    ready: boolean;
-    endpoint?: Endpoint<DevtoolsApiForContentScript>;
-    port?: Runtime.Port;
-  };
-}
-
-type Action =
-  | {type: 'webpage-ready'}
-  | {type: 'devtools-ready'; port: Runtime.Port}
-  | {type: 'devtools-disconnected'; port: Runtime.Port};
-
-function reducer(state: State, action: Action): State {
-  switch (action.type) {
-    case 'webpage-ready': {
-      if (state.webpage.ready) return state;
-
-      exposeWebpage(state.webpage.endpoint, state.devtools.endpoint);
-
-      return {
-        ...state,
-        webpage: {
-          ...state.webpage,
-          ready: true,
-        },
-      };
-    }
-    case 'devtools-ready': {
-      // Might need to catch when devtools reload and let this through
-      // For reload, will need to make sure to unmount the webpage if it already painted some ui.
-      if (state.devtools.ready) return state;
-      if (!state.webpage.ready) return state;
-
-      const endpoint = createDevtoolsEndpoint(action.port);
-
-      // Expose both devtools and webpage methods since both rely on the new port
-      exposeDevtools(endpoint, state.webpage.endpoint);
-      exposeWebpage(state.webpage.endpoint, state.devtools.endpoint);
-
-      return state;
-    }
-    case 'devtools-disconnected': {
-      if (state.devtools.port !== action.port) return state;
-
-      state.webpage.endpoint?.call.unmountDevtools();
-
-      return {
-        ...state,
-        devtools: {
-          ...state.devtools,
-          port: undefined,
-          endpoint: undefined,
-        },
-      };
-    }
-  }
-}
-
-export function contentScript0() {
-  const current: Current = {};
-
-  setup({devtoolsPort: undefined});
-
-  browser.runtime.onConnect.addListener(onConnectListener);
-
-  const contentScriptPort = browser.runtime.connect({
-    name: 'content-script',
-  });
-  contentScriptPort.onMessage.addListener(onAcceptedPortListener);
-
-  async function onAcceptedPortListener(
-    message: any,
-    devtoolsPort: Runtime.Port,
-  ) {
-    if (message?.type === 'accept-port' && message?.sender === 'dev') {
-      return setup({devtoolsPort});
-    }
-  }
-
-  async function onConnectListener(devtoolsPort: Runtime.Port) {
-    devtoolsPort.postMessage({type: 'accept-port', sender: 'content-script'});
-
-    const listener = (message: any) => {
-      if (message.type === 'ready' && message.sender === 'dev') {
-        setup({devtoolsPort});
-      }
-    };
-    devtoolsPort.onMessage.addListener(listener);
-  }
-
-  async function setup({devtoolsPort}: {devtoolsPort?: Runtime.Port}) {
-    try {
-      await current.webpage?.call.unmountDevtools();
-    } catch (error) {
-      console.log('webpage terminate failed');
-    }
-
-    if (devtoolsPort) {
-      // Create a brand new devtools endpoint
-      const devtools = createDevtoolsEndpoint(devtoolsPort);
-
-      // Use the same webpage endpoint or create a new one if there's none.
-      const webpage = current.webpage ?? createWebpageEndpoint();
-
-      // Even if the webpage already existed, the methods exposed to the webpage
-      // depend on the new dev tools endpoint, so we need to re-expose all methods anyway.
-      exposeWebpage(webpage, devtools);
-      exposeDevtools(devtools, webpage);
-
-      devtoolsPort.onDisconnect.addListener(() => {
-        if (current.port === devtoolsPort) {
-          current.port = undefined;
-        }
-        current.webpage?.call.unmountDevtools();
-      });
-
-      current.devtools = devtools;
-      current.webpage = webpage;
-      current.port = devtoolsPort;
-
-      webpage.call.mountDevtools();
-    } else {
-      const webpage = current.webpage ?? createWebpageEndpoint();
-      exposeWebpage(webpage);
-      current.webpage = webpage;
-    }
-  }
-}
-
-function createDevtoolsEndpoint(port: Runtime.Port) {
-  return createEndpoint<DevtoolsApiForContentScript>(fromPort(port), {
-    callable: ['getRemoteChannel', 'getApi'],
-  });
-}
-
-function createWebpageEndpoint() {
-  const endpoint = createEndpoint<WebpageApi>(
-    fromWebpage({context: 'content-script'}),
-    {
-      callable: ['mountDevtools', 'unmountDevtools', 'log'],
-      createEncoder: createUnsafeEncoder,
-    },
-  );
-
-  exposeWebpage(endpoint);
-
-  return endpoint;
-}
-
-// When the webpage mounts, it starts requesting a channel from the devtools.
-// If the devtools is not yet opened and we can't return the channel from the content-script,
-// we return an empty promise and resolve it when the devtools ends up opening.
-let channelPromiseResolve:
-  | ((value: RemoteChannel | PromiseLike<RemoteChannel>) => void)
-  | undefined;
-
-function exposeWebpage(
-  webpage: Endpoint<WebpageApi>,
-  devtools?: Endpoint<DevtoolsApiForContentScript>,
-) {
-  if (channelPromiseResolve && devtools) {
-    devtools.call
-      .getRemoteChannel()
-      .then(channelPromiseResolve)
-      .catch(() => console.error('Could not return a channel promise'));
-
-    channelPromiseResolve = undefined;
-  }
-
-  const contentScriptApiForWebpage: ContentScriptApiForWebpage = {
-    showWebpageUsesAside() {
-      browser.runtime.sendMessage({type: WEBPAGE_INITIATED_CONNECTION});
-    },
-    async getRemoteChannel() {
-      if (!devtools) {
-        return new Promise((resolve) => {
-          channelPromiseResolve = resolve;
-        });
-      }
-
-      return devtools.call.getRemoteChannel();
-    },
-    getLocalStorage(keys) {
-      return browser.storage.local.get(keys);
-    },
-    setLocalStorage(items) {
-      return browser.storage.local.set(items);
-    },
-    async getApi() {
-      if (!devtools) {
-        throw new Error('Cannot get api since no devtools is connected');
-      }
-
-      const api = await devtools.call.getApi();
-      retain(api);
-
-      return api;
-    },
-    ready() {
-      return webpage.call.mountDevtools();
-    },
-  };
-
-  webpage.expose(contentScriptApiForWebpage);
-}
-
-function exposeDevtools(
-  devtools: Endpoint<DevtoolsApiForContentScript>,
-  webpage: Endpoint<WebpageApi>,
-) {
-  const contentScriptApiForDevtools: ContentScriptApiForDevtools = {
-    mountDevtools() {
-      return webpage.call.mountDevtools();
-    },
-    unmountDevtools() {
-      return webpage.call.unmountDevtools();
-    },
-    log(source, ...params) {
-      return webpage.call.log(source, ...params);
-    },
-  };
-
-  devtools.expose(contentScriptApiForDevtools);
 }

--- a/app/src/foundation/ContentScript/api.ts
+++ b/app/src/foundation/ContentScript/api.ts
@@ -1,0 +1,88 @@
+import {
+  WebpageApi,
+  DevtoolsApiForContentScript,
+  ContentScriptApiForWebpage,
+  ContentScriptApiForDevtools,
+} from '@aside/core';
+import {Endpoint, retain} from '@remote-ui/rpc';
+import {type RemoteChannel} from '@remote-ui/core';
+
+import {WEBPAGE_INITIATED_CONNECTION} from './messages';
+import {Dispatch} from './types';
+
+// When the webpage mounts, it starts requesting a channel from the devtools.
+// If the devtools is not yet opened and we can't return the channel from the content-script,
+// we return an empty promise and resolve it when the devtools ends up opening.
+let channelPromiseResolve:
+  | ((value: RemoteChannel | PromiseLike<RemoteChannel>) => void)
+  | undefined;
+
+export function exposeWebpage(
+  webpage: Endpoint<WebpageApi>,
+  devtools: Endpoint<DevtoolsApiForContentScript> | undefined,
+  dispatch: Dispatch,
+) {
+  if (channelPromiseResolve && devtools) {
+    devtools.call
+      .getRemoteChannel()
+      .then(channelPromiseResolve)
+      .catch(() => console.error('Could not return a channel promise'));
+
+    channelPromiseResolve = undefined;
+  }
+
+  const contentScriptApiForWebpage: ContentScriptApiForWebpage = {
+    showWebpageUsesAside() {
+      browser.runtime.sendMessage({type: WEBPAGE_INITIATED_CONNECTION});
+    },
+    async getRemoteChannel() {
+      if (!devtools) {
+        return new Promise((resolve) => {
+          channelPromiseResolve = resolve;
+        });
+      }
+
+      return devtools.call.getRemoteChannel();
+    },
+    getLocalStorage(keys) {
+      return browser.storage.local.get(keys);
+    },
+    setLocalStorage(items) {
+      return browser.storage.local.set(items);
+    },
+    async getApi() {
+      if (!devtools) {
+        throw new Error('Cannot get api since no devtools is connected');
+      }
+
+      const api = await devtools.call.getApi();
+      retain(api);
+
+      return api;
+    },
+    ready() {
+      dispatch({type: 'webpage-ready'});
+    },
+  };
+
+  webpage.expose(contentScriptApiForWebpage);
+}
+
+export function exposeDevtools(
+  devtools: Endpoint<DevtoolsApiForContentScript>,
+  webpage: Endpoint<WebpageApi>,
+) {
+  const contentScriptApiForDevtools: ContentScriptApiForDevtools = {
+    mountDevtools() {
+      return webpage.call.mountDevtools();
+    },
+    unmountDevtools() {
+      return webpage.call.unmountDevtools();
+    },
+    log(source, ...params) {
+      return webpage.call.log(source, ...params);
+    },
+  };
+
+  devtools.expose(contentScriptApiForDevtools);
+}

--- a/app/src/foundation/ContentScript/endpoints.ts
+++ b/app/src/foundation/ContentScript/endpoints.ts
@@ -1,0 +1,22 @@
+import {
+  DevtoolsApiForContentScript,
+  WebpageApi,
+  fromWebpage,
+} from '@aside/core';
+import {createEndpoint} from '@remote-ui/rpc';
+import {Runtime} from 'webextension-polyfill';
+
+import {createUnsafeEncoder, fromPort} from '../Remote';
+
+export function createDevtoolsEndpoint(port: Runtime.Port) {
+  return createEndpoint<DevtoolsApiForContentScript>(fromPort(port), {
+    callable: ['getRemoteChannel', 'getApi'],
+  });
+}
+
+export function createWebpageEndpoint() {
+  return createEndpoint<WebpageApi>(fromWebpage({context: 'content-script'}), {
+    callable: ['mountDevtools', 'unmountDevtools', 'log'],
+    createEncoder: createUnsafeEncoder,
+  });
+}

--- a/app/src/foundation/ContentScript/reducer.ts
+++ b/app/src/foundation/ContentScript/reducer.ts
@@ -1,0 +1,100 @@
+import {signal, Signal} from '@preact/signals-core';
+
+import {Action, Dispatch, State} from './types';
+import {createDevtoolsEndpoint, createWebpageEndpoint} from './endpoints';
+import {exposeDevtools, exposeWebpage} from './api';
+
+function reducer(state: State, action: Action, dispatch: Dispatch): State {
+  switch (action.type) {
+    case 'init': {
+      const endpoint = createWebpageEndpoint();
+
+      // Even if we don't have a devtools endpoint yet to allow all messages,
+      // we still need to expose the methods on the endpoint
+      // to respond to simpler actions like updating the extension badge.
+      exposeWebpage(endpoint, undefined, dispatch);
+
+      return {
+        ...state,
+        webpage: {
+          ...state.webpage,
+          endpoint,
+        },
+      };
+    }
+    case 'webpage-ready': {
+      if (state.webpage.ready) return state;
+      // Potential impossible state where webpage is ready
+      // before content-script. There's no evidence that this happens for now.
+      if (!state.webpage.endpoint) return state;
+
+      const devtoolsEndpoint =
+        'endpoint' in state.devtools ? state.devtools.endpoint : undefined;
+
+      exposeWebpage(state.webpage.endpoint, devtoolsEndpoint, dispatch);
+
+      return {
+        ...state,
+        webpage: {
+          ...state.webpage,
+          ready: true,
+          endpoint: state.webpage.endpoint,
+        },
+      };
+    }
+    case 'devtools-ready': {
+      // Since we always create a webpage endpoint in the content-script
+      // before the webpage is even opened, this should not happen.
+      if (!state.webpage.endpoint) return state;
+
+      // When a devtools port is already mounted, unmount the devtools
+      // in the webpage. When the devtools port changes, the remote
+      // still contains references to functions that do not exist
+      // in the new devtools. Removing the UI wipes any function references
+      // pointing to the old/destroyed host.
+      if (state.devtools.ready) {
+        state.webpage.endpoint?.call.unmountDevtools();
+      }
+
+      const endpoint = createDevtoolsEndpoint(action.port);
+
+      exposeDevtools(endpoint, state.webpage.endpoint);
+      exposeWebpage(state.webpage.endpoint, endpoint, dispatch);
+
+      return {
+        ...state,
+        devtools: {
+          port: action.port,
+          endpoint,
+          ready: true,
+        },
+      };
+    }
+    case 'devtools-disconnected': {
+      // Another devtools panel could connect while the other listener is still around.
+      // In that case we don't want to unmount and destroy the communication
+      // that's in place between the new devtools endpoint and the webpage.
+      if (state.devtools.ready && state.devtools.port !== action.port)
+        return state;
+
+      state.webpage.endpoint?.call.unmountDevtools();
+
+      return {
+        ...state,
+        devtools: {
+          ready: false,
+        },
+      };
+    }
+  }
+}
+
+export function createReducer(initialState: State): [Signal<State>, Dispatch] {
+  const state = signal(initialState);
+
+  const dispatch: Dispatch = (action) => {
+    state.value = reducer(state.value, action, dispatch);
+  };
+
+  return [state, dispatch];
+}

--- a/app/src/foundation/ContentScript/tests/ContentScript.test.ts
+++ b/app/src/foundation/ContentScript/tests/ContentScript.test.ts
@@ -71,13 +71,17 @@ describe('ContentScript', () => {
 
       contentScript();
 
-      expect(mockCreateEndpoint).not.toHaveBeenCalled();
+      expect(mockCreateEndpoint).not.toHaveBeenCalledWith(expect.anything(), {
+        callable: ['getRemoteChannel', 'getApi'],
+      });
 
       const onAcceptedPortListener = mockOnMessageListener.mock.calls[0][0];
 
       onAcceptedPortListener('hello', createPort());
 
-      expect(mockCreateEndpoint).not.toHaveBeenCalled();
+      expect(mockCreateEndpoint).not.toHaveBeenCalledWith(expect.anything(), {
+        callable: ['getRemoteChannel', 'getApi'],
+      });
     });
 
     describe('when the devtools sent a message to accept the port', () => {
@@ -99,7 +103,9 @@ describe('ContentScript', () => {
 
         contentScript();
 
-        expect(mockCreateEndpoint).not.toHaveBeenCalled();
+        expect(mockCreateEndpoint).not.toHaveBeenCalledWith(expect.anything(), {
+          callable: ['getRemoteChannel', 'getApi'],
+        });
 
         const onAcceptedPortListener = mockOnMessageListener.mock.calls[0][0];
 
@@ -130,15 +136,6 @@ describe('ContentScript', () => {
         });
 
         contentScript();
-
-        expect(mockCreateEndpoint).not.toHaveBeenCalled();
-
-        const onAcceptedPortListener = mockOnMessageListener.mock.calls[0][0];
-
-        await onAcceptedPortListener(
-          {type: 'accept-port', sender: 'dev'},
-          createPort(),
-        );
 
         expect(mockCreateEndpoint).toHaveBeenCalledWith(expect.anything(), {
           callable: ['mountDevtools', 'unmountDevtools', 'log'],

--- a/app/src/foundation/ContentScript/types.ts
+++ b/app/src/foundation/ContentScript/types.ts
@@ -1,0 +1,48 @@
+import {DevtoolsApiForContentScript, WebpageApi} from '@aside/core';
+import {Endpoint} from '@remote-ui/rpc';
+import {Runtime} from 'webextension-polyfill';
+
+export interface State {
+  webpage: Webpage;
+  devtools: Devtools;
+}
+
+/**
+ * The state of the webpage.
+ * When the content-script creates the endpoint,
+ * it exists but we don't know if the webpage has connected yet
+ * and is ready to mount the app.
+ */
+export type Webpage =
+  | {
+      ready: false;
+      endpoint?: Endpoint<WebpageApi>;
+    }
+  | {
+      ready: true;
+      endpoint: Endpoint<WebpageApi>;
+    };
+
+/**
+ * The state of the devtools.
+ * Contrary to the webpage, the endpoint can't be created
+ * ahead of time, and we need to wait until a port connects
+ * to the content-script.
+ */
+export type Devtools =
+  | {
+      ready: false;
+    }
+  | {
+      ready: true;
+      port: Runtime.Port;
+      endpoint: Endpoint<DevtoolsApiForContentScript>;
+    };
+
+export type Action =
+  | {type: 'init'}
+  | {type: 'webpage-ready'}
+  | {type: 'devtools-ready'; port: Runtime.Port}
+  | {type: 'devtools-disconnected'; port: Runtime.Port};
+
+export type Dispatch = (action: Action) => void;

--- a/examples/graphql/src/Devtools.tsx
+++ b/examples/graphql/src/Devtools.tsx
@@ -52,6 +52,16 @@ export function Devtools() {
     [graphQLMonitor],
   );
 
+  const [ready, setReady] = useState(false);
+
+  useEffect(() => {
+    setTimeout(() => {
+      setReady(true);
+    }, 0);
+  }, []);
+
+  if (!ready) return null;
+
   return (
     <Aside>
       <AsideDevtools>

--- a/examples/graphql/src/Devtools.tsx
+++ b/examples/graphql/src/Devtools.tsx
@@ -52,16 +52,6 @@ export function Devtools() {
     [graphQLMonitor],
   );
 
-  const [ready, setReady] = useState(false);
-
-  useEffect(() => {
-    setTimeout(() => {
-      setReady(true);
-    }, 0);
-  }, []);
-
-  if (!ready) return null;
-
   return (
     <Aside>
       <AsideDevtools>

--- a/packages/core/src/endpoints.ts
+++ b/packages/core/src/endpoints.ts
@@ -99,6 +99,7 @@ export interface ContentScriptApiForWebpage extends RemoteApi {
   setLocalStorage(items: {[key: string]: any}): Promise<void>;
   getApi(): Promise<StatelessExtensionApi>;
   showWebpageUsesAside(): void;
+  ready(): void;
 }
 
 export interface ContentScriptApiForDevtools extends RemoteApi {

--- a/packages/react/src/components/DevTools.tsx
+++ b/packages/react/src/components/DevTools.tsx
@@ -67,7 +67,8 @@ export function Devtools({children}: PropsWithChildren<{}>) {
     };
 
     contentScript.expose(webpageApi);
-  }, [setDevtoolsRoot, mountDevtools]);
+    contentScript.call.ready();
+  }, [mountDevtools]);
 
   const handleUnmount = useCallback(() => {
     release(channelRef.current);
@@ -176,6 +177,7 @@ function createContentScriptEndpoint() {
         'setLocalStorage',
         'getApi',
         'showWebpageUsesAside',
+        'ready',
       ],
     },
   );

--- a/yarn.lock
+++ b/yarn.lock
@@ -2673,6 +2673,11 @@
     "@pnpm/network.ca-file" "^1.0.1"
     config-chain "^1.1.11"
 
+"@preact/signals-core@^1.1.5":
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/@preact/signals-core/-/signals-core-1.5.0.tgz#5d34db4d3c242c93e1cefb7ce8b2d10ecbdbfa79"
+  integrity sha512-U2diO1Z4i1n2IoFgMYmRdHWGObNrcuTRxyNEn7deSq2cru0vj0583HYQZHsAqcs7FE+hQyX3mjIV7LAfHCvy8w==
+
 "@radix-ui/primitive@1.0.1":
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@radix-ui/primitive/-/primitive-1.0.1.tgz#e46f9958b35d10e9f6dc71c497305c22e3e55dbd"


### PR DESCRIPTION
Fixes https://github.com/alxclark/aside/issues/46

When the webpage loaded after the content-script (>100ms after) the devtools UI would never be shown. The previous content-script implementation always accounted that the webpage was ready right away which is not true on bigger projects when there's a lot of api calls and delay until the aside react component is rendered.