### PR TITLE
Add capabilities feature with network support

### DIFF
--- a/.changeset/shy-buckets-tan.md
+++ b/.changeset/shy-buckets-tan.md
@@ -1,0 +1,6 @@
+---
+'@aside/react': patch
+'@aside/core': patch
+---
+
+Add capabilities support

--- a/app/src/foundation/ContentScript/api.ts
+++ b/app/src/foundation/ContentScript/api.ts
@@ -50,12 +50,12 @@ export function exposeWebpage(
     setLocalStorage(items) {
       return browser.storage.local.set(items);
     },
-    async getApi() {
+    async getApi(options) {
       if (!devtools) {
         throw new Error('Cannot get api since no devtools is connected');
       }
 
-      const api = await devtools.call.getApi();
+      const api = await devtools.call.getApi(options);
       retain(api);
 
       return api;

--- a/app/src/foundation/api/network.ts
+++ b/app/src/foundation/api/network.ts
@@ -3,102 +3,90 @@ import {
   NetworkRequest,
   StatelessExtensionApiOnHost,
 } from '@aside/core';
-import {useCallback, useEffect, useMemo} from 'react';
+import {useMemo} from 'react';
 import {signal, effect} from '@preact/signals-core';
 import {createRemoteSubscribable} from '@remote-ui/async-subscription';
 
 export function useNetworkApi(): ApiCreator<
   StatelessExtensionApiOnHost['network']
 > {
-  const networkRequests = useMemo(() => {
-    return signal<NetworkRequest[]>([]);
-  }, []);
-
-  const {subscribable: requests, clear: clearSubscription} = useMemo(() => {
-    return {
-      subscribable: createRemoteSubscribable({
-        subscribe: (callback) => {
-          const dispose = effect(() => {
-            callback(networkRequests.value);
-          });
-
-          return () => dispose();
-        },
-        get current() {
-          return networkRequests.value;
-        },
-      }),
-      clear: () => {
-        networkRequests.value = [];
-      },
-    };
-  }, [networkRequests]);
-
-  const requestSubscribers = useMemo(
-    () => new Set<(request: NetworkRequest) => void>(),
-    [],
-  );
-
-  // Read HAR to retrieve requests that happened before the devtools was ready.
-  useEffect(() => {
-    // getHAR is not typed correctly
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    /** @ts-ignore */
-    browser.devtools.network.getHAR((har) => {
-      networkRequests.value = har.entries;
-    });
-  }, [networkRequests]);
-
-  useEffect(() => {
-    const listener = async (rawRequest: any) => {
-      const request: any = {};
-
-      // Loop through the properties of the Proxy and copy them to the new object
-      // eslint-disable-next-line guard-for-in
-      for (const property in rawRequest) {
-        request[property] = rawRequest[property];
-      }
-
-      networkRequests.value = [...networkRequests.value, request];
-
-      requestSubscribers.forEach((callback) => callback(request));
-    };
-
-    browser.devtools.network.onRequestFinished.addListener(listener);
-
-    return () =>
-      browser.devtools.network.onRequestFinished.removeListener(listener);
-  }, [networkRequests, requestSubscribers]);
-
-  const onRequestFinished = useCallback(
-    async (callback: any) => {
-      requestSubscribers.add(callback);
-
-      return () => {
-        requestSubscribers.delete(callback);
-      };
-    },
-    [requestSubscribers],
-  );
-
-  const reset = useCallback(() => {
-    clearSubscription();
-    requestSubscribers.clear();
-  }, [clearSubscription, requestSubscribers]);
-
   const api: ApiCreator<StatelessExtensionApiOnHost['network']>['api'] =
     useMemo(
-      () => async () =>
-        [
-          {
-            clear: clearSubscription,
-            onRequestFinished,
-            requests,
-          },
-          reset,
-        ],
-      [clearSubscription, onRequestFinished, requests, reset],
+      () =>
+        async ({capabilities}) => {
+          const networkCapability = capabilities?.includes('network');
+          const networkRequests = signal<NetworkRequest[]>([]);
+          const listeners = new Set<(request: NetworkRequest) => void>();
+
+          const listener = async (rawRequest: any) => {
+            const request: any = {};
+
+            // Loop through the properties of the Proxy and copy them to the new object
+            // eslint-disable-next-line guard-for-in
+            for (const property in rawRequest) {
+              request[property] = rawRequest[property];
+            }
+
+            networkRequests.value = [...networkRequests.value, request];
+
+            listeners.forEach((callback) => callback(request));
+          };
+
+          if (networkCapability) {
+            // Load initial requests from HAR
+            await new Promise<void>((resolve) => {
+              // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+              /** @ts-ignore */
+              browser.devtools.network.getHAR((har) => {
+                networkRequests.value = har.entries;
+
+                resolve();
+              });
+            });
+
+            // For subsequent requests, setup a listener
+            browser.devtools.network.onRequestFinished.addListener(listener);
+          }
+
+          const onRequestFinished = async (callback: any) => {
+            if (!networkCapability) return () => {};
+
+            listeners.add(callback);
+
+            return () => {
+              listeners.delete(callback);
+            };
+          };
+
+          const reset = () => {
+            listeners.clear();
+            browser.devtools.network.onRequestFinished.removeListener(listener);
+          };
+
+          return [
+            {
+              clear: () => {
+                networkRequests.value = [];
+              },
+              onRequestFinished,
+              requests: createRemoteSubscribable({
+                subscribe: (callback) => {
+                  const dispose = effect(() => {
+                    callback(networkRequests.value);
+                  });
+
+                  return () => dispose();
+                },
+                get current() {
+                  return networkRequests.value;
+                },
+              }),
+            },
+            reset,
+          ];
+        },
+      [],
     );
 
-  return useMemo(() => ({api, reset}), [api, reset]);
+  return useMemo(() => ({api}), [api]);
 }

--- a/examples/graphql/src/Devtools.tsx
+++ b/examples/graphql/src/Devtools.tsx
@@ -16,6 +16,7 @@ import {
   TabsTrigger,
   TabsContent,
 } from '@aside/chrome-ui-remote';
+import {Capability} from '@aside/core';
 import {
   Aside,
   Devtools as AsideDevtools,
@@ -52,9 +53,11 @@ export function Devtools() {
     [graphQLMonitor],
   );
 
+  const capabilities: Capability[] = useMemo(() => ['network'], []);
+
   return (
     <Aside>
-      <AsideDevtools>
+      <AsideDevtools capabilities={capabilities}>
         <AppActivityProvider activity={appActivity} refreshCache={refreshCache}>
           <AsideApp />
         </AppActivityProvider>

--- a/packages/core/src/endpoints.ts
+++ b/packages/core/src/endpoints.ts
@@ -22,8 +22,10 @@ export type GetterSetterStatefulSubscribableTuple<T> = [
   (value: SetStateAction<T>) => void,
 ];
 
+export type Capability = 'network';
+
 export interface ApiContext {
-  __futureApiContext: null;
+  capabilities?: Capability[];
 }
 
 type ResetFunction = () => void;
@@ -97,7 +99,9 @@ export interface ContentScriptApiForWebpage extends RemoteApi {
     keys?: string | {[key: string]: any} | string[] | null | undefined,
   ): Promise<{[key: string]: any}>;
   setLocalStorage(items: {[key: string]: any}): Promise<void>;
-  getApi(): Promise<StatelessExtensionApi>;
+  getApi(options?: {
+    capabilities?: Capability[];
+  }): Promise<StatelessExtensionApi>;
   showWebpageUsesAside(): void;
   ready(): void;
 }
@@ -112,7 +116,9 @@ export interface ContentScriptApiForDevtools extends RemoteApi {
 
 export interface DevtoolsApiForContentScript extends RemoteApi {
   getRemoteChannel(): RemoteChannel;
-  getApi(): Promise<StatelessExtensionApi>;
+  getApi(options?: {
+    capabilities?: Capability[];
+  }): Promise<StatelessExtensionApi>;
 }
 
 export interface WebpageApi extends RemoteApi {


### PR DESCRIPTION
Having the network api supported in an extension brings a significant impact on memory consumption because it possibly need to parse through hundreds/thousands of requests (especially when using ESM with Vite). To combat the side effect of the api while still offering the feature to apps, a new prop called `capabilities` was added to the `Devtools` component of Aside. This new prop allows consumers to define if they want access to a given api (in this case network).

The majority of apis won't necessarily be tied to a capability, but when adding a new feature means a tradeoff in performance for all consumers, it will be put behind a capability.

The network api will need some further optimization, but this unlocks simpler use-case like state management.